### PR TITLE
suppress libxml's PHP warnings to fix HTTP errors

### DIFF
--- a/docs/update.xml
+++ b/docs/update.xml
@@ -5,10 +5,10 @@
     <element>http2push</element>
     <type>plugin</type>
     <folder>system</folder>
-    <version>1.1.5</version>
+    <version>1.1.6</version>
     <infourl title="bluewallweb/plg_http2push">https://github.com/bluewallweb/plg_http2push/releases/latest</infourl>
     <downloads>
-      <downloadurl type="full" format="zip">https://github.com/bluewallweb/plg_http2push/archive/1.1.5.zip</downloadurl>
+      <downloadurl type="full" format="zip">https://github.com/bluewallweb/plg_http2push/archive/1.1.6.zip</downloadurl>
     </downloads>
     <tags>
       <tag>stable</tag>

--- a/http2push.php
+++ b/http2push.php
@@ -123,11 +123,19 @@
         $resources = [];
         // Fetch the rendered application response body
         $response  = new \DOMDocument();
+        // Suppress PHP-level warnings from parsing a malformed document and
+        // preserve the current libxml logging preference
+        $logging   = libxml_use_internal_errors(true);
+        // Parse the HTML document body for processing
         $response->loadHTML($this->app->getBody());
+        // Restore the previous logging preference for libxml
+        libxml_use_internal_errors($logging);
+        // Import the `DOMDocument` tree into a `SimpleXMLElement` instance
         $response  = simplexml_import_dom($response);
-        // Extract all applicable external resources from the DOM
+        // Extract all applicable external resources from the DOM using XPath
         $search    = $response->xpath('//script[@src]|'.
           '//link[@href and @rel]|//img[@src]');
+        // Iterate over each resource to process it for preload/preconnect
         foreach ($search as $item) {
           // Process each item based on its element name
           if (strtolower($item->getName()) === 'img') {

--- a/http2push.xml
+++ b/http2push.xml
@@ -3,7 +3,7 @@
 <extension version="3.8" type="plugin" group="system" method="upgrade">
   <name>PLG_SYSTEM_HTTP2PUSH</name>
   <description>PLG_HTTP2PUSH_DESCRIPTION</description>
-  <version>1.1.5</version>
+  <version>1.1.6</version>
   <author>Clay Freeman</author>
   <authorEmail>info@bluewall.com</authorEmail>
   <authorUrl>https://bluewall.com</authorUrl>


### PR DESCRIPTION
When loading a page that results in a malformed HTML response, libxml can emit
enough PHP warnings to overflow the stderr buffer size in FPM-based setups,
causing a "502 Bad Gateway" response.

This commit should suppress these warnings by configuring libxml during runtime
to log errors internally and not use PHP's error logging facilities.