### PR TITLE
remove dependency on SimpleXMLElement

### DIFF
--- a/docs/update.xml
+++ b/docs/update.xml
@@ -5,10 +5,10 @@
     <element>http2push</element>
     <type>plugin</type>
     <folder>system</folder>
-    <version>1.2.1</version>
+    <version>1.2.2</version>
     <infourl title="bluewallweb/plg_http2push">https://github.com/bluewallweb/plg_http2push/releases/latest</infourl>
     <downloads>
-      <downloadurl type="full" format="zip">https://github.com/bluewallweb/plg_http2push/archive/1.2.1.zip</downloadurl>
+      <downloadurl type="full" format="zip">https://github.com/bluewallweb/plg_http2push/archive/1.2.2.zip</downloadurl>
     </downloads>
     <tags>
       <tag>stable</tag>

--- a/http2push.xml
+++ b/http2push.xml
@@ -3,7 +3,7 @@
 <extension version="3.8" type="plugin" group="system" method="upgrade">
   <name>PLG_SYSTEM_HTTP2PUSH</name>
   <description>PLG_SYSTEM_HTTP2PUSH_DESCRIPTION</description>
-  <version>1.2.1</version>
+  <version>1.2.2</version>
   <author>Clay Freeman</author>
   <authorEmail>info@bluewall.com</authorEmail>
   <authorUrl>https://bluewall.com</authorUrl>

--- a/install.php
+++ b/install.php
@@ -65,11 +65,10 @@ final class plgSystemHttp2PushInstallerScript extends InstallerScript {
   /**
    * Checks that the required PHP API's are installed.
    *
-   * This plugin depends on the `\DOMDocument` and `\SimpleXMLElement` classes
-   * and the `\simplexml_import_dom()` and `\libxml_use_internal_errors()`
-   * functions available in PHP's XML extension on many distributions or by
-   * statically compiling PHP with the `--enable-dom` and
-   * `--enable-simplexml` flags.
+   * This plugin depends on the `\DOMDocument` and `\DOMXPath` classes and the
+   * `\libxml_use_internal_errors()` function available in PHP's XML extension
+   * on many distributions or by statically compiling PHP with the
+   * `--enable-dom` and `--enable-simplexml` flags.
    *
    * @param   string            $type    The type of change (install,
    *                                     update, ...).
@@ -82,11 +81,12 @@ final class plgSystemHttp2PushInstallerScript extends InstallerScript {
     // Check a list of classes that are required for this plugin to work
     $classes = \array_map([$this, 'classExists'], [
       '\\DOMDocument',
-      '\\SimpleXMLElement'
+      '\\DOMElement',
+      '\\DOMNode',
+      '\\DOMXPath'
     ]);
     // Check a list of functions that are required for this plugin to work
     $functions = \array_map([$this, 'functionExists'], [
-      '\\simplexml_import_dom',
       '\\libxml_use_internal_errors'
     ]);
     // Ensure that all of the required symbols exist


### PR DESCRIPTION
This commit removes the dependency on `\SimpleXMLElement` for all XPath related
functionality in favor of using `\DOMXPath`.

Also introduced in this commit is a restriction on the `parseDocumentBody()`
method of the plugin to require that all documents have '<!DOCTYPE html' at the
beginning of the document body. This ensures that only documents meant for
client display are processed for HTTP/2 Push, excluding JSON responses, etc.