### PR TITLE
fix update site URL broken in previous commit

### DIFF
--- a/http2push.xml
+++ b/http2push.xml
@@ -32,6 +32,6 @@
     </fields>
   </config>
   <updateservers>
-    <server type="extension" name="PLG_SYSTEM_HTTP2PUSH">https://bluewallweb.github.io/plg_system_http2push/update.xml</server>
+    <server type="extension" name="PLG_SYSTEM_HTTP2PUSH">https://bluewallweb.github.io/plg_http2push/update.xml</server>
   </updateservers>
 </extension>


### PR DESCRIPTION
It appears that the update site URL was broken in a previous commit; this commit
fixes the URL.