### PR TITLE
Resolve PHP8 install error - joomla 3.10

### DIFF
--- a/install.php
+++ b/install.php
@@ -77,7 +77,7 @@ final class plgSystemHttp2PushInstallerScript extends InstallerScript {
    * @return  bool                       `TRUE` if all prerequisites are
    *                                     satisfied, `FALSE` otherwise
    */
-  public function preflight(string $type, InstallerAdapter $parent): bool {
+  public function preflight($type, $parent) {
     // Check a list of classes that are required for this plugin to work
     $classes = \array_map([$this, 'classExists'], [
       '\\DOMDocument',


### PR DESCRIPTION
PHP 8 was complaining because the joomla core function for preflight we were extending doesn't have types for joomla3.10